### PR TITLE
Update install to work in dedicated build folder

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -57,11 +57,19 @@ curl -Lo "$source_path" "$download_url"
   # For versions after 7.7.21 use cmake instead of gnu autoconf tools
   # Here we compare versions without the '-devel' suffix (if any)
   if [[ "$(compare_version ${ASDF_INSTALL_VERSION%-devel} 7.7.21)" == '>' ]]; then
+    # Create an out-of-source build directory to satisfy CMake requirements
+    mkdir -p build
+    cd build
+    
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_INSTALL_PREFIX="$ASDF_INSTALL_PATH" \
       -DSWIPL_PACKAGES_X=OFF \
-      -DSWIPL_PACKAGES_JAVA=OFF
+      -DSWIPL_PACKAGES_JAVA=OFF \
+      ..
+      
+    make
+    make install
   else
     ./configure \
         --prefix="$ASDF_INSTALL_PATH" \
@@ -69,8 +77,8 @@ curl -Lo "$source_path" "$download_url"
         --without-jpl \
         --without-xpce \
         --disable-libdirversion
+        
+    make
+    make install
   fi
-
-  make
-  make install
 )

--- a/bin/install
+++ b/bin/install
@@ -67,9 +67,6 @@ curl -Lo "$source_path" "$download_url"
       -DSWIPL_PACKAGES_X=OFF \
       -DSWIPL_PACKAGES_JAVA=OFF \
       ..
-      
-    make
-    make install
   else
     ./configure \
         --prefix="$ASDF_INSTALL_PATH" \
@@ -77,8 +74,8 @@ curl -Lo "$source_path" "$download_url"
         --without-jpl \
         --without-xpce \
         --disable-libdirversion
-        
-    make
-    make install
   fi
+
+  make
+  make install
 )


### PR DESCRIPTION
Hi,

I am not sure if you are working together with the original author so wanted to cross post the change here.
It was a fix for installing `10.0.2` on an M2 Macbook.
More information can be found in the original repo: https://github.com/mracos/asdf-swiprolog/pull/13